### PR TITLE
refactor: use an older C compiler standard

### DIFF
--- a/examples/ffi/README.md
+++ b/examples/ffi/README.md
@@ -2,9 +2,6 @@
 
 The following in an example of how to call the `wardstone` Rust library from C.
 
-> **Note**:
-> This requires a C compiler with some features from the C23 standard enabled.
-
 # Instructions
 
 First compile the Rust library using the following.
@@ -16,7 +13,7 @@ cargo build --release
 And then compile the example binary and run it.
 
 ```bash
-cc -std=c2x ./main.c -L../../target/release/ -lwardstone 
+cc ./main.c -L../../target/release/ -lwardstone 
 ./a.out
 ```
 

--- a/examples/ffi/main.c
+++ b/examples/ffi/main.c
@@ -4,16 +4,15 @@
 #include <stdint.h>
 #include <time.h>
 
-uint16_t get_current_year() {
-  auto unix_time_now = time(nullptr);
-  auto localtime_now = localtime(&unix_time_now);
-  return localtime_now->tm_year + 1900;
+int get_current_year() {
+  time_t now = time(NULL);
+  struct tm* local_time = localtime(&now);
+  return local_time->tm_year + 1900;
 }
 
 int main(void) {
-  auto current_year = get_current_year();
-
+  uint16_t current_year = get_current_year();
   assert(lenstra_validate_hash(&SHA1, current_year) == false);
   assert(lenstra_validate_hash(&SHA256, current_year) == true);
-  assert(lenstra_validate_hash(nullptr, current_year) == -1);
+  assert(lenstra_validate_hash(NULL, current_year) == -1);
 }


### PR DESCRIPTION
This makes the example more accessible for users that are not running a compiler with the latest C standard revision as of writing.