### PR TITLE
feat: add more crate types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,8 @@ name = "wardstone"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib", "staticlib"]
 
 [dependencies]
 


### PR DESCRIPTION
Setting `lib` in particular is important as running documentation tests does not work with all the other crate types.