### PR TITLE
feat: allow use of NIST curves in the BSI guide

### DIFF
--- a/crates/core/src/standard/bsi.rs
+++ b/crates/core/src/standard/bsi.rs
@@ -25,6 +25,9 @@ const CUTOFF_YEAR_RSA: u16 = 2023; // See p. 17.
 
 static SPECIFIED_CURVES: Lazy<HashSet<Ecc>> = Lazy::new(|| {
   let mut s = HashSet::new();
+  s.insert(P256);
+  s.insert(P384);
+  s.insert(P521);
   s.insert(BRAINPOOLP256R1);
   s.insert(BRAINPOOLP320R1);
   s.insert(BRAINPOOLP384R1);
@@ -137,7 +140,8 @@ impl Standard for Bsi {
   /// parameters "that are provided by a trustworthy authority"
   /// (see p. 73), this function conservatively deems any curve that is
   /// not explicitly stated as non-compliant. This means only the
-  /// Brainpool curves are considered compliant.
+  /// Brainpool and NIST curves that satisfy minimum security
+  /// requirements are considered compliant.
   ///
   /// # Example
   ///
@@ -355,9 +359,9 @@ mod tests {
   use crate::{test_ecc, test_ffc, test_hash, test_hash_based, test_ifc, test_symmetric};
 
   test_ecc!(p224, Bsi, &P224, Err(BRAINPOOLP256R1));
-  test_ecc!(p256, Bsi, &P256, Err(BRAINPOOLP256R1));
-  test_ecc!(p384, Bsi, &P384, Err(BRAINPOOLP256R1));
-  test_ecc!(p521, Bsi, &P521, Err(BRAINPOOLP256R1));
+  test_ecc!(p256, Bsi, &P256, Ok(BRAINPOOLP256R1));
+  test_ecc!(p384, Bsi, &P384, Ok(BRAINPOOLP384R1));
+  test_ecc!(p521, Bsi, &P521, Ok(BRAINPOOLP512R1));
   test_ecc!(w25519, Bsi, &W25519, Err(BRAINPOOLP256R1));
   test_ecc!(w448, Bsi, &W448, Err(BRAINPOOLP256R1));
   test_ecc!(curve25519, Bsi, &CURVE25519, Err(BRAINPOOLP256R1));


### PR DESCRIPTION
Some guides in the series (TR-02102-1 and TR-02102-2) permit the usage of NIST curves P256, P384, and P521, even though the main guide (TR-02102-1) does not mention any other curves outside the Brainpool curves.

**TLS**

![curves_tls](https://github.com/tshakalekholoane/wardstone/assets/23554017/116184dd-1088-4f3f-86a6-1fad54360f3d)

**SSH**

![curves_ssh](https://github.com/tshakalekholoane/wardstone/assets/23554017/7656fb6a-b264-450d-bd3f-a1bf4ab6edd5)


