### PR TITLE
refactor: update the name of the library

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,13 +63,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Generate header and build dynamic library
+      - name: Generate header and build static library
         run: cargo build --release --all-features
 
       - name: Build FFI example
         working-directory: ./examples/ffi/
         run: |
-          cc -I ../../target/ ./main.c ../../target/release/libwardstone_ffi.a \
+          cc -I ../../target/ ./main.c ../../target/release/libwardstone.a \
             -o ../../target/release/ffi_example
 
       - name: Run FFI example

--- a/crates/cmd/Cargo.toml
+++ b/crates/cmd/Cargo.toml
@@ -30,3 +30,6 @@ serde =  { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"
 wardstone_core = { path = "../core" }
 x509-parser = "0.15.1"
+
+[lib]
+doc = false

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
+name = "wardstone"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]

--- a/examples/ffi/README.md
+++ b/examples/ffi/README.md
@@ -15,7 +15,7 @@ The static library and associated header file will be placed in the `target` dir
 Finally, compile the C example and run it using the following commands in the current directory. This assumes you are on a Unix system.
 
 ```bash
-cc -I ../../target/ ./main.c ../../target/release/libwardstone_ffi.a
+cc -I ../../target/ ./main.c ../../target/release/libwardstone.a
 ./a.out
 ```
 


### PR DESCRIPTION
The static and dynamic libraries should use the same name as the header file i.e., libwardstone.so instead of libwardstone_ffi.so as suggested by @msirringhaus.